### PR TITLE
chore: add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,27 @@
+; Top-most EditorConfig file for NetMedic.
+; https://editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+
+[*.{md,markdown}]
+trim_trailing_whitespace = false
+
+[*.{yml,yaml,json,toml}]
+indent_size = 2
+
+[*.{ps1,psm1}]
+end_of_line = crlf
+
+[Makefile]
+indent_style = tab
+
+[*.rb]
+indent_size = 2


### PR DESCRIPTION
Pins indentation, line endings, and trailing-whitespace rules so the repo renders consistently across VS Code, JetBrains, Vim, etc.